### PR TITLE
gcc 4.8/4.9 autodetect in Make.config

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -11,10 +11,13 @@ VPATH = $(SRCDIR)
 X86 = i.86\|pentium.*\|[pk][56]\|nexgen\|viac3\|6x86\|athlon.*\|i86pc
 X86_64 = x86_64
 
-# Pintos doesn't compile/run properly using gcc 4.3+. Force 4.1 for now.
-CCPROG = /usr/class/cs140/x86_64/bin/i586-elf-gcc
-ifeq ($(strip $(shell command -v $(CCPROG) 2> /dev/null)),)
-  CCPROG = gcc
+# gcc version < 5 is required for Pintos
+ifneq ("$(wildcard $(shell which gcc-4.8))", "")
+	CCPROG=gcc-4.8
+else ifneq ("$(wildcard $(shell which gcc-4.9))", "")
+	CCPROG=gcc-4.9
+else
+	CCPROG=gcc
 endif
 
 ifneq (0, $(shell expr `uname -m` : '$(X86)'))


### PR DESCRIPTION
It would be kind of neat to have it detect *any* valid version of gcc. This works, though.