### PR TITLE
Fix warnings for SIGVTALRM and "raw" drives

### DIFF
--- a/utils/pintos
+++ b/utils/pintos
@@ -623,10 +623,10 @@ sub run_qemu {
       if defined $jitter;
     my (@cmd) = ('qemu');
     push (@cmd, '-device', 'isa-debug-exit');
-    push (@cmd, '-hda', $disks[0]) if defined $disks[0];
-    push (@cmd, '-hdb', $disks[1]) if defined $disks[1];
-    push (@cmd, '-hdc', $disks[2]) if defined $disks[2];
-    push (@cmd, '-hdd', $disks[3]) if defined $disks[3];
+    push (@cmd, '-drive', 'file='.$disks[0].',format=raw,index=0,media=disk') if defined $disks[0];
+    push (@cmd, '-drive', 'file='.$disks[1].',format=raw,index=1,media=disk') if defined $disks[1];
+    push (@cmd, '-drive', 'file='.$disks[2].',format=raw,index=2,media=disk') if defined $disks[2];
+    push (@cmd, '-drive', 'file='.$disks[3].',format=raw,index=3,media=disk') if defined $disks[3];
     push (@cmd, '-m', $mem);
     push (@cmd, '-net', 'none');
     push (@cmd, '-nographic') if $vga eq 'none';
@@ -914,30 +914,13 @@ sub get_load_average {
 # Calls setitimer to set a timeout, then execs what was passed to us.
 sub exec_setitimer {
     if (defined $timeout) {
-	if ($ ge 5.8.0) {
 	    eval "
               use Time::HiRes qw(setitimer ITIMER_VIRTUAL);
               setitimer (ITIMER_VIRTUAL, $timeout, 0);
             ";
-	} else {
-	    { exec ("setitimer-helper", $timeout, @_); };
-	    exit 1 if !$!{ENOENT};
-	    print STDERR "warning: setitimer-helper is not installed, so ",
-	      "CPU time limit will not be enforced\n";
-	}
     }
     exec (@_);
     exit (1);
-}
-
-sub SIGVTALRM {
-    use Config;
-    my $i = 0;
-    foreach my $name (split(' ', $Config{sig_name})) {
-	return $i if $name eq 'VTALRM';
-	$i++;
-    }
-    return 0;
 }
 
 # find_in_path ($program)


### PR DESCRIPTION
The test .error files should be empty, now.